### PR TITLE
fix: resize is causing scroll on mobile

### DIFF
--- a/package/src/Resizer/SplitPaneResizer.module.css
+++ b/package/src/Resizer/SplitPaneResizer.module.css
@@ -43,6 +43,7 @@
   z-index: 2;
   box-sizing: border-box;
   background-clip: padding-box;
+  touch-action: none;
 
   /* Knob */
   &:after {


### PR DESCRIPTION
Hi @gfazioli, I saw someone mention an issue on the mantine discord channel that on mobile when we resize the panel the mobile scroll is not blocked. this PR fixes that issue

link to discord message
https://discord.com/channels/854810300876062770/890965830727241785/1269563613816029194

let me know what you think 