### PR TITLE
fix(types): declare children on SplitResizerBaseProps

### DIFF
--- a/package/src/Resizer/SplitResizer.tsx
+++ b/package/src/Resizer/SplitResizer.tsx
@@ -163,6 +163,14 @@ export type SPLIT_PANE_RESIZE_SIZES = {
 };
 
 export interface SplitResizerBaseProps extends SplitResizerContextProps {
+  /**
+   * Custom content rendered inside the resizer button. Useful for adding
+   * an icon or a label next to the default knob. Already supported at
+   * runtime via the underlying `UnstyledButton`; this prop just makes it
+   * visible to TypeScript.
+   */
+  children?: React.ReactNode;
+
   /** Event called when resizer is double-clicked */
   onDoubleClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
 

--- a/package/src/Split.test.tsx
+++ b/package/src/Split.test.tsx
@@ -129,6 +129,20 @@ describe('Split', () => {
     expect(container).toBeTruthy();
   });
 
+  it('renders custom children passed to Split.Resizer', () => {
+    render(
+      <Split>
+        <Split.Pane>Pane 1</Split.Pane>
+        <Split.Resizer>
+          <span data-testid="resizer-child">grip</span>
+        </Split.Resizer>
+        <Split.Pane>Pane 2</Split.Pane>
+      </Split>
+    );
+
+    expect(screen.getByTestId('resizer-child')).toBeInTheDocument();
+  });
+
   it('snaps vertical drag movements to configured points', () => {
     const { pane1, pane2, resizer } = setupVerticalSplit(
       { snapPoints: [200, 400, 600], snapTolerance: 10 },


### PR DESCRIPTION
## Summary

- Adds `children?: React.ReactNode` to `SplitResizerBaseProps` so TypeScript stops complaining when consumers pass JSX content into `<Split.Resizer>...</Split.Resizer>`.
- No runtime change — `Split.Resizer` already renders `<UnstyledButton {...rest} />`, so children have always reached the DOM. This is purely a public-type alignment.
- Adds a regression test that mounts `<Split.Resizer>` with a child node and asserts the child renders.

Closes #45

## Test plan

- [x] `yarn clean && yarn build`
- [x] `yarn test` (28/28 passing, including the new `renders custom children passed to Split.Resizer` test)
- [ ] Verify the TypeScript error reported by @enisdenjo no longer occurs in a downstream project

## Follow-up (not in this PR)

A dedicated `knob` slot prop (in the spirit of Mantine's `leftSection` / `rightSection` on `Button`/`ActionIcon`) would be the more idiomatic way to *replace* the visual knob. That's a minor-release surface expansion and will be tracked separately.