### PR TITLE
fix(resizer): fire onResizing and onResizeEnd on double-click reset

### DIFF
--- a/package/src/Resizer/SplitResizer.tsx
+++ b/package/src/Resizer/SplitResizer.tsx
@@ -791,6 +791,39 @@ export const SplitResizer = factory<SplitResizerFactory>((_props) => {
     beforeRef?.current?.resetInitialSize?.(e);
     afterRef?.current?.resetInitialSize?.(e);
 
+    // Report final sizes after reset
+    if (beforeRef?.current && afterRef?.current) {
+      const beforePane = beforeRef.current.splitPane;
+      const afterPane = afterRef.current.splitPane;
+
+      if (beforePane && afterPane) {
+        const beforePaneSizes = {
+          width: beforePane.getBoundingClientRect().width,
+          height: beforePane.getBoundingClientRect().height,
+        };
+        const afterPaneSizes = {
+          width: afterPane.getBoundingClientRect().width,
+          height: afterPane.getBoundingClientRect().height,
+        };
+
+        onResizing?.({
+          beforePane: beforePaneSizes,
+          afterPane: afterPaneSizes,
+        });
+
+        onResizeEnd?.({
+          beforePane: beforePaneSizes,
+          afterPane: afterPaneSizes,
+        });
+
+        beforeRef.current.onResizing?.(beforePaneSizes);
+        afterRef.current.onResizing?.(afterPaneSizes);
+
+        beforeRef.current.onResizeEnd?.(beforePaneSizes);
+        afterRef.current.onResizeEnd?.(afterPaneSizes);
+      }
+    }
+
     onDoubleClick?.(e);
   };
 


### PR DESCRIPTION
Hey! 👋

This PR fixes the double-click reset not firing `onResizing` and `onResizeEnd` callbacks.

## The Problem

When double-clicking the resizer to reset pane sizes, only `resetInitialSize` and `onDoubleClick` were called. Users couldn't track pane sizes after a reset because `onResizing` and `onResizeEnd` weren't fired.

## The Solution

Added calls to `onResizing` and `onResizeEnd` after the reset, matching the behavior of mouse drag and touch resize handlers.

## What Changed

- Modified `handleDoubleClick` to fire `onResizing` and `onResizeEnd` callbacks with final pane sizes

## Testing

- Verified the fix fires callbacks correctly
- No regression on existing resize behavior

Fixes #44