### PR TITLE
fix(resizer): emit onResizeEnd after double-click reset

### DIFF
--- a/package/src/Resizer/SplitResizer.tsx
+++ b/package/src/Resizer/SplitResizer.tsx
@@ -180,7 +180,11 @@ export interface SplitResizerBaseProps extends SplitResizerContextProps {
   /** Event called continuously while panes are being resized (mouse move / touch move) */
   onResizing?: (sizes: SPLIT_PANE_RESIZE_SIZES) => void;
 
-  /** Event called when a resize operation ends (mouse up / touch end) */
+  /**
+   * Event called when a resize operation ends. Fires after mouse up,
+   * touch end, and also after a double-click reset (with the post-reset
+   * pane sizes).
+   */
   onResizeEnd?: (sizes: SPLIT_PANE_RESIZE_SIZES) => void;
 
   /**
@@ -779,8 +783,15 @@ export const SplitResizer = factory<SplitResizerFactory>((_props) => {
   };
 
   /**
-   * Resets both adjacent panes to their initial sizes and fires the
-   * `onDoubleClick` callback. Triggered by a double-click on the resizer.
+   * Resets both adjacent panes to their initial sizes, fires the
+   * `onDoubleClick` callback, and then emits `onResizeEnd` on the
+   * resizer and on each adjacent pane with the post-reset dimensions.
+   * Triggered by a double-click on the resizer.
+   *
+   * The `onResizeEnd` emission is deferred to the next animation frame:
+   * `resetInitialSize` applies the new dimensions via state, so the
+   * DOM has not yet re-rendered when this handler returns — measuring
+   * synchronously would report the *pre-reset* sizes.
    *
    * @param e - The originating double-click mouse event
    */
@@ -792,6 +803,31 @@ export const SplitResizer = factory<SplitResizerFactory>((_props) => {
     afterRef?.current?.resetInitialSize?.(e);
 
     onDoubleClick?.(e);
+
+    requestAnimationFrame(() => {
+      const beforePane = beforeRef?.current?.splitPane;
+      const afterPane = afterRef?.current?.splitPane;
+      if (!beforePane || !afterPane) {
+        return;
+      }
+
+      const beforePaneSizes = {
+        width: beforePane.getBoundingClientRect().width,
+        height: beforePane.getBoundingClientRect().height,
+      };
+      const afterPaneSizes = {
+        width: afterPane.getBoundingClientRect().width,
+        height: afterPane.getBoundingClientRect().height,
+      };
+
+      onResizeEnd?.({
+        beforePane: beforePaneSizes,
+        afterPane: afterPaneSizes,
+      });
+
+      beforeRef?.current?.onResizeEnd?.(beforePaneSizes);
+      afterRef?.current?.onResizeEnd?.(afterPaneSizes);
+    });
   };
 
   return (

--- a/package/src/Split.test.tsx
+++ b/package/src/Split.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@mantine-tests/core';
-import { fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { Split } from './Split';
 
 type TestSplitProps = Omit<React.ComponentProps<typeof Split>, 'children'>;
@@ -127,6 +127,32 @@ describe('Split', () => {
       </Split>
     );
     expect(container).toBeTruthy();
+  });
+
+  it('fires onResizeEnd after a double-click reset with the post-reset pane sizes', async () => {
+    const onResizeEnd = jest.fn();
+    const { pane1, pane2, resizer } = setupVerticalSplit({}, { onResizeEnd });
+
+    // Drag the resizer to change pane widths away from their initial values
+    fireEvent.mouseDown(resizer);
+    fireEvent.mouseMove(document, { clientX: 500 });
+    fireEvent.mouseUp(document);
+
+    onResizeEnd.mockClear();
+
+    // Double-click triggers `resetInitialSize` on both panes; the handler
+    // measures sizes on the next animation frame and emits `onResizeEnd`.
+    fireEvent.doubleClick(resizer);
+
+    await waitFor(() => {
+      expect(onResizeEnd).toHaveBeenCalledTimes(1);
+    });
+
+    const arg = onResizeEnd.mock.calls[0][0];
+    expect(arg.beforePane.width).toBe(300);
+    expect(arg.afterPane.width).toBe(700);
+    expect(pane1.style.width).toBe('300px');
+    expect(pane2.style.width).toBe('700px');
   });
 
   it('renders custom children passed to Split.Resizer', () => {


### PR DESCRIPTION
## Summary

- After a double-click reset on `Split.Resizer`, `onResizeEnd` is now emitted on the resizer and on each adjacent pane with the post-reset dimensions. Previously the reset was invisible to consumers that track pane sizes via `onResizeEnd`.
- Measurement is deferred to the next animation frame because `resetInitialSize` applies the new dimensions via state — a synchronous read would still return the pre-reset sizes.
- `onResizing` is intentionally **not** emitted: the reset is atomic, and that callback is reserved for the in-progress drag stream.
- Updated JSDoc on `onResizeEnd` to reflect the new trigger.

Closes #44

## Test plan

- [x] `yarn clean && yarn build`
- [x] `yarn test` (29/29 passing, including the new `fires onResizeEnd after a double-click reset with the post-reset pane sizes` test)
- [ ] Validated by @enisdenjo in a downstream project

## Notes

The fix is purely additive — anyone with an existing `onResizeEnd` handler now also receives an event after a double-click reset. There is no behavior change for code that doesn't subscribe to `onResizeEnd`.