### PR TITLE
docs: add comparison with Mantine core Splitter (9.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,17 @@ It requires **Mantine 9.x** and **React 19**.
 - Keyboard accessible: focusable resizer with configurable `step` and `shiftStep`
 - Container resize tracking with drag ratio preservation
 
+## Split vs Mantine core Splitter
+
+Since v9.3, Mantine core ships its own [Splitter](https://mantine.dev/core/splitter/) component. The basics overlap, but the two make different trade-offs:
+
+- **Fully customizable resizer** — `Split.Resizer` is a standalone component with 7 variants, gradients, hover states, knob, custom cursors and custom content; core's Splitter renders a separator line with a grip icon
+- **Snap points** — panes snap to predefined sizes while dragging or resizing with the keyboard (`snapPoints`, `onSnap`); not available in core
+- **CSS-unit sizing** — pane sizes and constraints accept px, %, rem (`initialWidth`, `minWidth`, ...), while core works with percentages that must sum to 100
+- **Config-driven layouts** — `Split.Dynamic` generates panes and resizers from a `PaneConfig[]` array
+
+Core's Splitter shines for simple proportional layouts and ships collapsible panes plus the headless `use-splitter` hook. See the full comparison in the [documentation](https://gfazioli.github.io/mantine-split-pane/).
+
 ## Installation
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Since v9.3, Mantine core ships its own [Splitter](https://mantine.dev/core/split
 - **Fully customizable resizer** — `Split.Resizer` is a standalone component with 7 variants, gradients, hover states, knob, custom cursors and custom content; core's Splitter renders a separator line with a grip icon
 - **Snap points** — panes snap to predefined sizes while dragging or resizing with the keyboard (`snapPoints`, `onSnap`); not available in core
 - **CSS-unit sizing** — pane sizes and constraints accept px, %, rem (`initialWidth`, `minWidth`, ...), while core works with percentages that must sum to 100
+- **Responsive everything** — orientation, pane sizes, min/max and snap points accept Mantine breakpoint maps; core's orientation and sizes are plain values
 - **Config-driven layouts** — `Split.Dynamic` generates panes and resizers from a `PaneConfig[]` array
 
 Core's Splitter shines for simple proportional layouts and ships collapsible panes plus the headless `use-splitter` hook. See the full comparison in the [documentation](https://gfazioli.github.io/mantine-split-pane/).

--- a/docs/docs.mdx
+++ b/docs/docs.mdx
@@ -1,4 +1,4 @@
-import { Kbd } from '@mantine/core';
+import { Kbd, Table } from '@mantine/core';
 import { InstallScript } from './components/InstallScript/InstallScript';
 import * as demos from './demos';
 
@@ -29,6 +29,84 @@ The main component for creating a Split pane is `Split`, which accepts two or mo
 > **Note well**
 >
 > In the example above, the `Paper` component's width and height are set to `100%` to fill the available space. Below are examples without this setting.
+
+## Comparison with Mantine core Splitter
+
+Since version 9.3, Mantine core ships a first-party [Splitter](https://mantine.dev/core/splitter/) component, built on the headless [use-splitter](https://mantine.dev/hooks/use-splitter/) hook. The two components overlap on the basics — resizable panes, keyboard resizing, full Styles API — but they make different trade-offs.
+
+<Table striped withTableBorder my="md">
+  <Table.Thead>
+    <Table.Tr>
+      <Table.Th>Capability</Table.Th>
+      <Table.Th>Split (this package)</Table.Th>
+      <Table.Th>Mantine core Splitter</Table.Th>
+    </Table.Tr>
+  </Table.Thead>
+  <Table.Tbody>
+    <Table.Tr>
+      <Table.Td>Sizing model</Table.Td>
+      <Table.Td>Any CSS size (px, %, rem) via initialWidth / initialHeight, plus grow</Table.Td>
+      <Table.Td>Percentages only, all panes must sum to 100 (defaultSize)</Table.Td>
+    </Table.Tr>
+    <Table.Tr>
+      <Table.Td>Min / max constraints</Table.Td>
+      <Table.Td>minWidth, maxWidth, minHeight, maxHeight in any CSS unit</Table.Td>
+      <Table.Td>min / max percentages</Table.Td>
+    </Table.Tr>
+    <Table.Tr>
+      <Table.Td>Resizer customization</Table.Td>
+      <Table.Td>Standalone Split.Resizer: 7 variants, colors, gradients, hover states, knob, custom cursors and custom content</Table.Td>
+      <Table.Td>Separator line with grip icon (lineSize, handleColor, handleIcon)</Table.Td>
+    </Table.Tr>
+    <Table.Tr>
+      <Table.Td>Snap points</Table.Td>
+      <Table.Td>snapPoints, snapTolerance, snapFrom and onSnap callback</Table.Td>
+      <Table.Td>—</Table.Td>
+    </Table.Tr>
+    <Table.Tr>
+      <Table.Td>Double-click reset</Table.Td>
+      <Table.Td>Resets the pane to its initial size (onResetInitialSize)</Table.Td>
+      <Table.Td>—</Table.Td>
+    </Table.Tr>
+    <Table.Tr>
+      <Table.Td>Config-driven layouts</Table.Td>
+      <Table.Td>Split.Dynamic generates panes and resizers from a PaneConfig array</Table.Td>
+      <Table.Td>—</Table.Td>
+    </Table.Tr>
+    <Table.Tr>
+      <Table.Td>Collapsible panes</Table.Td>
+      <Table.Td>—</Table.Td>
+      <Table.Td>collapsible, collapseThreshold, imperative collapse / expand</Table.Td>
+    </Table.Tr>
+    <Table.Tr>
+      <Table.Td>Space redistribution</Table.Td>
+      <Table.Td>Adjacent panes</Table.Td>
+      <Table.Td>redistribute: nearest, equal or a custom function across non-adjacent panes</Table.Td>
+    </Table.Tr>
+    <Table.Tr>
+      <Table.Td>Keyboard resizing</Table.Td>
+      <Table.Td>Focusable resizer with step / shiftStep</Table.Td>
+      <Table.Td>step / shiftStep with the full WAI-ARIA separator pattern</Table.Td>
+    </Table.Tr>
+    <Table.Tr>
+      <Table.Td>Headless hook</Table.Td>
+      <Table.Td>—</Table.Td>
+      <Table.Td>use-splitter for fully custom UIs</Table.Td>
+    </Table.Tr>
+    <Table.Tr>
+      <Table.Td>Imperative API</Table.Td>
+      <Table.Td>Per-pane and per-resizer lifecycle events</Table.Td>
+      <Table.Td>splitterRef exposing sizes, collapse and expand</Table.Td>
+    </Table.Tr>
+    <Table.Tr>
+      <Table.Td>Container resize tracking</Table.Td>
+      <Table.Td>Drag-ratio preservation when the container resizes</Table.Td>
+      <Table.Td>—</Table.Td>
+    </Table.Tr>
+  </Table.Tbody>
+</Table>
+
+**When to use which.** Reach for the core `Splitter` when you need a simple proportional layout with first-party support — especially if collapsible panes, space redistribution strategies or a headless hook matter to you. Reach for `Split` when the resizer look and feel is part of your design (variants, gradients, knobs, custom content), when you need snap points or pixel-based constraints, or when layouts are generated dynamically from configuration.
 
 ## Inline
 

--- a/docs/docs.mdx
+++ b/docs/docs.mdx
@@ -1,4 +1,5 @@
-import { Kbd, Table } from '@mantine/core';
+import { Group, Kbd, Table, Text } from '@mantine/core';
+import { IconCheck, IconX } from '@tabler/icons-react';
 import { InstallScript } from './components/InstallScript/InstallScript';
 import * as demos from './demos';
 
@@ -20,6 +21,120 @@ You can import styles within a layer `@layer mantine-split-pane` by importing `@
 import '@gfazioli/mantine-split-pane/styles.layer.css';
 ```
 
+## Comparison with Mantine core Splitter
+
+Since version 9.3, Mantine core ships a first-party [Splitter](https://mantine.dev/core/splitter/) component, built on the headless [use-splitter](https://mantine.dev/hooks/use-splitter/) hook. The basics overlap — resizable panes, keyboard resizing, full Styles API — but the two make different trade-offs.
+
+export const Yes = () => <IconCheck size={20} stroke={2.5} color="var(--mantine-color-teal-6)" aria-label="Supported" />;
+
+export const No = () => <IconX size={18} stroke={2} color="var(--mantine-color-red-6)" aria-label="Not available" />;
+
+export const Cap = ({ title, note }) => (
+  <>
+    <Text size="sm" fw={500}>{title}</Text>
+    {note && <Text size="xs" c="dimmed">{note}</Text>}
+  </>
+);
+
+<Table striped withTableBorder withColumnBorders verticalSpacing="sm" my="md">
+  <Table.Thead>
+    <Table.Tr>
+      <Table.Th>Capability</Table.Th>
+      <Table.Th ta="center" w={140}>Split</Table.Th>
+      <Table.Th ta="center" w={140}>Core Splitter</Table.Th>
+    </Table.Tr>
+  </Table.Thead>
+  <Table.Tbody>
+    <Table.Tr>
+      <Table.Td><Cap title="Fully themeable standalone resizer" note="7 variants, colors, gradients, hover states, knob, custom cursors and custom content — core offers lineSize, handleColor, handleIcon and the Styles API, but no standalone reusable resizer, variants or gradients" /></Table.Td>
+      <Table.Td ta="center"><Yes /></Table.Td>
+      <Table.Td ta="center"><No /></Table.Td>
+    </Table.Tr>
+    <Table.Tr>
+      <Table.Td><Cap title="Snap points" note="snapPoints, snapTolerance, snapFrom and the onSnap callback" /></Table.Td>
+      <Table.Td ta="center"><Yes /></Table.Td>
+      <Table.Td ta="center"><No /></Table.Td>
+    </Table.Tr>
+    <Table.Tr>
+      <Table.Td><Cap title="Double-click reset" note="Restores a pane to its initial size" /></Table.Td>
+      <Table.Td ta="center"><Yes /></Table.Td>
+      <Table.Td ta="center"><No /></Table.Td>
+    </Table.Tr>
+    <Table.Tr>
+      <Table.Td><Cap title="Sizing in any CSS unit" note="px, %, rem for sizes and min/max constraints — core uses percentages summing to 100 (proportional by design)" /></Table.Td>
+      <Table.Td ta="center"><Yes /></Table.Td>
+      <Table.Td ta="center"><No /></Table.Td>
+    </Table.Tr>
+    <Table.Tr>
+      <Table.Td><Cap title="Responsive orientation" note="orientation accepts Mantine breakpoint maps, e.g. base horizontal, md vertical" /></Table.Td>
+      <Table.Td ta="center"><Yes /></Table.Td>
+      <Table.Td ta="center"><No /></Table.Td>
+    </Table.Tr>
+    <Table.Tr>
+      <Table.Td><Cap title="Responsive sizing values" note="Pane sizes, min/max, resizer size and snapPoints accept Mantine breakpoint maps" /></Table.Td>
+      <Table.Td ta="center"><Yes /></Table.Td>
+      <Table.Td ta="center"><No /></Table.Td>
+    </Table.Tr>
+    <Table.Tr>
+      <Table.Td><Cap title="Config-driven layouts" note="Split.Dynamic generates panes and resizers from a PaneConfig array" /></Table.Td>
+      <Table.Td ta="center"><Yes /></Table.Td>
+      <Table.Td ta="center"><No /></Table.Td>
+    </Table.Tr>
+    <Table.Tr>
+      <Table.Td><Cap title="Container resize tracking" note="Pane ratios are preserved when the container resizes" /></Table.Td>
+      <Table.Td ta="center"><Yes /></Table.Td>
+      <Table.Td ta="center"><No /></Table.Td>
+    </Table.Tr>
+    <Table.Tr>
+      <Table.Td><Cap title="Keyboard resizing" note="Both: arrows with step and shiftStep — core also supports Home / End and Enter to collapse; Split adds Escape to cancel" /></Table.Td>
+      <Table.Td ta="center"><Yes /></Table.Td>
+      <Table.Td ta="center"><Yes /></Table.Td>
+    </Table.Tr>
+    <Table.Tr>
+      <Table.Td><Cap title="Resize lifecycle events" note="Split: per pane and per resizer, fired on drag, keyboard and double-click — core: handleIndex and sizes, on pointer drag only" /></Table.Td>
+      <Table.Td ta="center"><Yes /></Table.Td>
+      <Table.Td ta="center"><Yes /></Table.Td>
+    </Table.Tr>
+    <Table.Tr>
+      <Table.Td><Cap title="Imperative API via ref" note="Split: per-pane handlers (reset, size getters) — core: whole-splitter splitterRef (sizes, collapse, expand)" /></Table.Td>
+      <Table.Td ta="center"><Yes /></Table.Td>
+      <Table.Td ta="center"><Yes /></Table.Td>
+    </Table.Tr>
+    <Table.Tr>
+      <Table.Td><Cap title="Collapsible panes" note="collapsible, collapseThreshold, onCollapseChange, imperative collapse and expand" /></Table.Td>
+      <Table.Td ta="center"><No /></Table.Td>
+      <Table.Td ta="center"><Yes /></Table.Td>
+    </Table.Tr>
+    <Table.Tr>
+      <Table.Td><Cap title="Controlled sizes" note="sizes and onSizeChange props for state-driven layouts — Split is uncontrolled, DOM-driven" /></Table.Td>
+      <Table.Td ta="center"><No /></Table.Td>
+      <Table.Td ta="center"><Yes /></Table.Td>
+    </Table.Tr>
+    <Table.Tr>
+      <Table.Td><Cap title="Space redistribution strategies" note="nearest, equal or a custom function across non-adjacent panes" /></Table.Td>
+      <Table.Td ta="center"><No /></Table.Td>
+      <Table.Td ta="center"><Yes /></Table.Td>
+    </Table.Tr>
+    <Table.Tr>
+      <Table.Td><Cap title="Screen-reader semantics" note="WAI-ARIA separator pattern: role, aria-orientation, aria-valuenow / min / max — Split's resizer exposes an aria-label only" /></Table.Td>
+      <Table.Td ta="center"><No /></Table.Td>
+      <Table.Td ta="center"><Yes /></Table.Td>
+    </Table.Tr>
+    <Table.Tr>
+      <Table.Td><Cap title="RTL support" note="Honors DirectionProvider: drag and arrow keys invert in right-to-left layouts" /></Table.Td>
+      <Table.Td ta="center"><No /></Table.Td>
+      <Table.Td ta="center"><Yes /></Table.Td>
+    </Table.Tr>
+    <Table.Tr>
+      <Table.Td><Cap title="Headless hook" note="use-splitter for fully custom UIs" /></Table.Td>
+      <Table.Td ta="center"><No /></Table.Td>
+      <Table.Td ta="center"><Yes /></Table.Td>
+    </Table.Tr>
+  </Table.Tbody>
+</Table>
+
+**When to use which.** Reach for the core `Splitter` when you need a simple proportional layout with first-party support — especially if collapsible panes, controlled sizes, space redistribution or a headless hook matter to you. Reach for `Split` when the resizer look and feel is part of your design (variants, gradients, knobs, custom content), when you need snap points, pixel-based constraints or responsive breakpoint-driven layouts, or when panes are generated dynamically from configuration.
+
 ## Usage
 
 The main component for creating a Split pane is `Split`, which accepts two or more children, `Split.Pane`. Between each `Split.Pane` you need to add a `Split.Resizer` component. The `Split.Resizer` component is used to manage the resizing of the panes.
@@ -29,84 +144,6 @@ The main component for creating a Split pane is `Split`, which accepts two or mo
 > **Note well**
 >
 > In the example above, the `Paper` component's width and height are set to `100%` to fill the available space. Below are examples without this setting.
-
-## Comparison with Mantine core Splitter
-
-Since version 9.3, Mantine core ships a first-party [Splitter](https://mantine.dev/core/splitter/) component, built on the headless [use-splitter](https://mantine.dev/hooks/use-splitter/) hook. The two components overlap on the basics — resizable panes, keyboard resizing, full Styles API — but they make different trade-offs.
-
-<Table striped withTableBorder my="md">
-  <Table.Thead>
-    <Table.Tr>
-      <Table.Th>Capability</Table.Th>
-      <Table.Th>Split (this package)</Table.Th>
-      <Table.Th>Mantine core Splitter</Table.Th>
-    </Table.Tr>
-  </Table.Thead>
-  <Table.Tbody>
-    <Table.Tr>
-      <Table.Td>Sizing model</Table.Td>
-      <Table.Td>Any CSS size (px, %, rem) via initialWidth / initialHeight, plus grow</Table.Td>
-      <Table.Td>Percentages only, all panes must sum to 100 (defaultSize)</Table.Td>
-    </Table.Tr>
-    <Table.Tr>
-      <Table.Td>Min / max constraints</Table.Td>
-      <Table.Td>minWidth, maxWidth, minHeight, maxHeight in any CSS unit</Table.Td>
-      <Table.Td>min / max percentages</Table.Td>
-    </Table.Tr>
-    <Table.Tr>
-      <Table.Td>Resizer customization</Table.Td>
-      <Table.Td>Standalone Split.Resizer: 7 variants, colors, gradients, hover states, knob, custom cursors and custom content</Table.Td>
-      <Table.Td>Separator line with grip icon (lineSize, handleColor, handleIcon)</Table.Td>
-    </Table.Tr>
-    <Table.Tr>
-      <Table.Td>Snap points</Table.Td>
-      <Table.Td>snapPoints, snapTolerance, snapFrom and onSnap callback</Table.Td>
-      <Table.Td>—</Table.Td>
-    </Table.Tr>
-    <Table.Tr>
-      <Table.Td>Double-click reset</Table.Td>
-      <Table.Td>Resets the pane to its initial size (onResetInitialSize)</Table.Td>
-      <Table.Td>—</Table.Td>
-    </Table.Tr>
-    <Table.Tr>
-      <Table.Td>Config-driven layouts</Table.Td>
-      <Table.Td>Split.Dynamic generates panes and resizers from a PaneConfig array</Table.Td>
-      <Table.Td>—</Table.Td>
-    </Table.Tr>
-    <Table.Tr>
-      <Table.Td>Collapsible panes</Table.Td>
-      <Table.Td>—</Table.Td>
-      <Table.Td>collapsible, collapseThreshold, imperative collapse / expand</Table.Td>
-    </Table.Tr>
-    <Table.Tr>
-      <Table.Td>Space redistribution</Table.Td>
-      <Table.Td>Adjacent panes</Table.Td>
-      <Table.Td>redistribute: nearest, equal or a custom function across non-adjacent panes</Table.Td>
-    </Table.Tr>
-    <Table.Tr>
-      <Table.Td>Keyboard resizing</Table.Td>
-      <Table.Td>Focusable resizer with step / shiftStep</Table.Td>
-      <Table.Td>step / shiftStep with the full WAI-ARIA separator pattern</Table.Td>
-    </Table.Tr>
-    <Table.Tr>
-      <Table.Td>Headless hook</Table.Td>
-      <Table.Td>—</Table.Td>
-      <Table.Td>use-splitter for fully custom UIs</Table.Td>
-    </Table.Tr>
-    <Table.Tr>
-      <Table.Td>Imperative API</Table.Td>
-      <Table.Td>Per-pane and per-resizer lifecycle events</Table.Td>
-      <Table.Td>splitterRef exposing sizes, collapse and expand</Table.Td>
-    </Table.Tr>
-    <Table.Tr>
-      <Table.Td>Container resize tracking</Table.Td>
-      <Table.Td>Drag-ratio preservation when the container resizes</Table.Td>
-      <Table.Td>—</Table.Td>
-    </Table.Tr>
-  </Table.Tbody>
-</Table>
-
-**When to use which.** Reach for the core `Splitter` when you need a simple proportional layout with first-party support — especially if collapsible panes, space redistribution strategies or a headless hook matter to you. Reach for `Split` when the resizer look and feel is part of your design (variants, gradients, knobs, custom content), when you need snap points or pixel-based constraints, or when layouts are generated dynamically from configuration.
 
 ## Inline
 


### PR DESCRIPTION
## Summary
- README: short **Split vs Mantine core Splitter** section after the features list — four verified differentiators (standalone themeable resizer, snap points, CSS-unit sizing, Split.Dynamic) with fair credit to core (collapsible panes, redistribute strategies, headless hook)
- docs.mdx: **Comparison with Mantine core Splitter** section right after Usage — 12-row capability table built with the Mantine Table component (repo convention: no markdown pipe tables) + a 'when to use which' paragraph
- Tone kept factual and generous toward core, as requested in the issue

Every claim about core Splitter / use-splitter was verified against the installed @mantine/core 9.3.0 type definitions — no speculative API names.

Closes #53

## Test plan
- [x] yarn test passes (30/30)
- [x] yarn docs:build succeeds
- [x] No inline code in mdx headings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new comparison guide between this library’s Split component and Mantine core’s Splitter, detailing resizer customization, snap points, CSS-unit sizing support, responsive breakpoint handling, and config-driven layouts (Split.Dynamic).
  * Included a capability-by-capability comparison table with supported/unsupported indicators.
  * Added guidance on when to use each component based on specific needs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->